### PR TITLE
Sort by file name

### DIFF
--- a/src/fuseops.c
+++ b/src/fuseops.c
@@ -126,7 +126,6 @@ static int mp3fs_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
     }
     
     for (i = 0; i < n; i++) {
-
         if (!skip) {
             struct stat st;
             


### PR DESCRIPTION
Simple mp3 players don't sort files by name. They just show track in order as files has written on disk.

Players that have sort files by name should show track list slightly faster with this patch.
