### PR TITLE
Proposal for adding VBR encoding

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,7 +2,7 @@ WARNINGS = -Wall -Wextra -Wconversion -Wno-sign-conversion
 AM_CFLAGS = -std=gnu99 $(fuse_CFLAGS) $(WARNINGS)
 AM_CXXFLAGS = -std=c++98 $(fuse_CFLAGS) $(WARNINGS)
 bin_PROGRAMS = mp3fs
-mp3fs_SOURCES = mp3fs.c fuseops.c transcode.cc transcode.h buffer.cc buffer.h coders.cc coders.h
+mp3fs_SOURCES = mp3fs.c fuseops.c transcode.cc transcode.h buffer.cc buffer.h coders.cc coders.h stats_cache.cc stats_cache.h
 mp3fs_LDADD	= $(fuse_LIBS)
 if HAVE_FLAC
 mp3fs_SOURCES += flac_decoder.cc flac_decoder.h

--- a/src/coders.cc
+++ b/src/coders.cc
@@ -34,9 +34,9 @@
 #endif
 
 /* Create instance of class derived from Encoder. */
-Encoder* Encoder::CreateEncoder(std::string file_type) {
+Encoder* Encoder::CreateEncoder(std::string file_type, size_t actual_size) {
 #ifdef HAVE_MP3
-    if (file_type == "mp3") return new Mp3Encoder();
+    if (file_type == "mp3") return new Mp3Encoder(actual_size);
 #endif
     return NULL;
 }

--- a/src/coders.h
+++ b/src/coders.h
@@ -69,12 +69,14 @@ public:
                                  int data_length) = 0;
     virtual void set_gain_db(const double dbgain) = 0;
     virtual int render_tag(Buffer& buffer) = 0;
+    virtual size_t get_actual_size() const = 0;
     virtual size_t calculate_size() const = 0;
     virtual int encode_pcm_data(const int32_t* const data[], int numsamples,
                                 int sample_size, Buffer& buffer) = 0;
     virtual int encode_finish(Buffer& buffer) = 0;
 
-    static Encoder* CreateEncoder(const std::string file_type);
+    static Encoder* CreateEncoder(const std::string file_type,
+	    size_t actual_size = 0);
 };
 
 /* Decoder class interface */
@@ -83,6 +85,8 @@ public:
     virtual ~Decoder() { };
 
     virtual int open_file(const char* filename) = 0;
+    /* The modified time of the decoder file */
+    virtual time_t mtime() = 0;
     virtual int process_metadata(Encoder* encoder) = 0;
     virtual int process_single_fr(Encoder* encoder, Buffer* buffer) = 0;
 

--- a/src/coders.h
+++ b/src/coders.h
@@ -76,7 +76,7 @@ public:
     virtual int encode_finish(Buffer& buffer) = 0;
 
     static Encoder* CreateEncoder(const std::string file_type,
-	    size_t actual_size = 0);
+            size_t actual_size = 0);
 };
 
 /* Decoder class interface */

--- a/src/flac_decoder.cc
+++ b/src/flac_decoder.cc
@@ -52,7 +52,7 @@ int FlacDecoder::open_file(const char* filename) {
     struct stat s;
     if (fstat(fd, &s) < 0) {
         mp3fs_debug("FLAC stat failed.");
-	close(fd);
+        close(fd);
         return -1;
     }
     mtime_ = s.st_mtime;
@@ -60,14 +60,14 @@ int FlacDecoder::open_file(const char* filename) {
     FILE *file = fdopen(fd, "r");
     if (file == 0) {
         mp3fs_debug("FLAC fdopen failed.");
-	close(fd);
+        close(fd);
         return -1;
     }
 
     /* Initialise decoder */
     if (init(file) != FLAC__STREAM_DECODER_INIT_STATUS_OK) {
         mp3fs_debug("FLAC init failed.");
-	fclose(file);
+        fclose(file);
         return -1;
     }
 

--- a/src/flac_decoder.h
+++ b/src/flac_decoder.h
@@ -32,6 +32,7 @@
 class FlacDecoder : public Decoder, private FLAC::Decoder::File {
 public:
     int open_file(const char* filename);
+    time_t mtime();
     int process_metadata(Encoder* encoder);
     int process_single_fr(Encoder* encoder, Buffer* buffer);
 protected:
@@ -42,6 +43,7 @@ protected:
 private:
     Encoder* encoder_c;
     Buffer* buffer_c;
+    time_t mtime_;
     FLAC::Metadata::StreamInfo info;
     typedef std::map<std::string,int> meta_map_t;
     static const meta_map_t create_meta_map();

--- a/src/fuseops.c
+++ b/src/fuseops.c
@@ -215,7 +215,6 @@ static int mp3fs_getattr(const char *path, struct stat *stbuf) {
         stbuf->st_size = transcoder_get_size(trans);
         stbuf->st_blocks = (stbuf->st_size + 512 - 1) / 512;
         
-        transcoder_finish(trans);
         transcoder_delete(trans);
     }
     
@@ -319,7 +318,7 @@ passthrough:
 open_fail:
     free(origpath);
 translate_fail:
-    if (read) {
+    if (read >= 0) {
         return (int)read;
     } else {
         return -errno;
@@ -363,7 +362,6 @@ static int mp3fs_release(const char *path, struct fuse_file_info *fi) {
     
     trans = (struct transcoder*)fi->fh;
     if (trans) {
-        transcoder_finish(trans);
         transcoder_delete(trans);
     }
     

--- a/src/fuseops.c
+++ b/src/fuseops.c
@@ -337,9 +337,20 @@ static int mp3fs_statfs(const char *path, struct statvfs *stbuf) {
     if (!origpath) {
         goto translate_fail;
     }
-    
+
+    /* pass-through for regular files */
+    if (statvfs(origpath, stbuf) == 0) {
+        goto passthrough;
+    } else {
+        /* Not really an error. */
+        errno = 0;
+    }
+
+    find_original(origpath);
+
     statvfs(origpath, stbuf);
-    
+
+passthrough:
     free(origpath);
 translate_fail:
     return -errno;

--- a/src/mp3_encoder.cc
+++ b/src/mp3_encoder.cc
@@ -236,7 +236,7 @@ void Mp3Encoder::set_gain_db(const double dbgain) {
 
 /*
  * Render the ID3 tag into the referenced Buffer. This should be the first
- * thing to go into the Buffer.  The ID3v1 tag will also be written 128
+ * thing to go into the Buffer. The ID3v1 tag will also be written 128
  * bytes from the calculated end of the buffer. It has a fixed size.
  */
 int Mp3Encoder::render_tag(Buffer& buffer) {
@@ -261,9 +261,9 @@ int Mp3Encoder::render_tag(Buffer& buffer) {
     /* Write v1 tag at end of buffer. */
     id3_tag_options(id3tag, ID3_TAG_OPTION_ID3V1, ~0);
     write_ptr = buffer.write_prepare(id3v1_tag_length,
-	    calculate_size() - id3v1_tag_length);
+            calculate_size() - id3v1_tag_length);
     if (!write_ptr) {
-	return -1;
+        return -1;
     }
     id3_tag_render(id3tag, write_ptr);
 
@@ -272,7 +272,7 @@ int Mp3Encoder::render_tag(Buffer& buffer) {
 
 /*
  * Get the actual number of bytes in the encoded file, i.e. without any
- * padding.  Valid only after encode_finish() has been called.
+ * padding. Valid only after encode_finish() has been called.
  */
 size_t Mp3Encoder::get_actual_size() const {
     return actual_size;
@@ -286,15 +286,15 @@ size_t Mp3Encoder::get_actual_size() const {
  */
 size_t Mp3Encoder::calculate_size() const {
     if (actual_size != 0) {
-	return actual_size;
+        return actual_size;
     } else if (params.vbr) {
-	return id3size + id3v1_tag_length + MAX_VBR_FRAME_SIZE
-	+ (uint64_t)lame_get_totalframes(lame_encoder)*144*params.bitrate*10
-	/ (lame_get_in_samplerate(lame_encoder)/100);
+        return id3size + id3v1_tag_length + MAX_VBR_FRAME_SIZE
+        + (uint64_t)lame_get_totalframes(lame_encoder)*144*params.bitrate*10
+        / (lame_get_in_samplerate(lame_encoder)/100);
     } else {
-	return id3size + id3v1_tag_length
-	+ (uint64_t)lame_get_totalframes(lame_encoder)*144*params.bitrate*10
-	/ (lame_get_out_samplerate(lame_encoder)/100);
+        return id3size + id3v1_tag_length
+        + (uint64_t)lame_get_totalframes(lame_encoder)*144*params.bitrate*10
+        / (lame_get_out_samplerate(lame_encoder)/100);
     }
 }
 
@@ -365,18 +365,18 @@ int Mp3Encoder::encode_finish(Buffer& buffer) {
     actual_size = buffer.tell() + id3v1_tag_length;
 
     /*
-     * Write the VBR tag data at id3size bytes after the beginning.  lame
+     * Write the VBR tag data at id3size bytes after the beginning. lame
      * already put dummy bytes here when lame_init_params() was called.
      */
     if (params.vbr) {
         uint8_t* write_ptr = buffer.write_prepare(MAX_VBR_FRAME_SIZE, id3size);
         if (!write_ptr) {
-	    return -1;
+            return -1;
         }
         size_t vbr_tag_size = lame_get_lametag_frame(lame_encoder, write_ptr,
-		MAX_VBR_FRAME_SIZE);
+                MAX_VBR_FRAME_SIZE);
         if (vbr_tag_size > MAX_VBR_FRAME_SIZE) {
-	   return -1;
+           return -1;
         }
     }
 

--- a/src/mp3_encoder.cc
+++ b/src/mp3_encoder.cc
@@ -29,6 +29,9 @@
 
 #include "transcode.h"
 
+/* Copied from lame */
+#define MAX_VBR_FRAME_SIZE 2880
+
 /* Keep these items in static scope. */
 namespace  {
 
@@ -62,7 +65,7 @@ static void lame_debug(const char *fmt, va_list list) {
  * particular file. Currently error handling is poor. If we run out
  * of memory, these routines will fail silently.
  */
-Mp3Encoder::Mp3Encoder() {
+Mp3Encoder::Mp3Encoder(size_t _actual_size) : actual_size(_actual_size) {
     id3tag = id3_tag_new();
 
     mp3fs_debug("LAME ready to initialize.");
@@ -72,9 +75,16 @@ Mp3Encoder::Mp3Encoder() {
     set_text_tag(METATAG_ENCODER, PACKAGE_NAME);
 
     /* Set lame parameters. */
-    lame_set_quality(lame_encoder, params.quality);
-    lame_set_brate(lame_encoder, params.bitrate);
-    lame_set_bWriteVbrTag(lame_encoder, 0);
+    if (params.vbr) {
+       lame_set_VBR(lame_encoder, vbr_mt);
+       lame_set_VBR_q(lame_encoder, params.quality);
+       lame_set_VBR_max_bitrate_kbps(lame_encoder, params.bitrate);
+       lame_set_bWriteVbrTag(lame_encoder, 1);
+    } else {
+       lame_set_quality(lame_encoder, params.quality);
+       lame_set_brate(lame_encoder, params.bitrate);
+       lame_set_bWriteVbrTag(lame_encoder, 0);
+    }
     lame_set_errorf(lame_encoder, &lame_error);
     lame_set_msgf(lame_encoder, &lame_msg);
     lame_set_debugf(lame_encoder, &lame_debug);
@@ -226,7 +236,7 @@ void Mp3Encoder::set_gain_db(const double dbgain) {
 
 /*
  * Render the ID3 tag into the referenced Buffer. This should be the first
- * thing to go into the Buffer. The ID3v1 tag will also be written 128
+ * thing to go into the Buffer.  The ID3v1 tag will also be written 128
  * bytes from the calculated end of the buffer. It has a fixed size.
  */
 int Mp3Encoder::render_tag(Buffer& buffer) {
@@ -250,10 +260,22 @@ int Mp3Encoder::render_tag(Buffer& buffer) {
 
     /* Write v1 tag at end of buffer. */
     id3_tag_options(id3tag, ID3_TAG_OPTION_ID3V1, ~0);
-    write_ptr = buffer.write_prepare(128, calculate_size() - 128);
+    write_ptr = buffer.write_prepare(id3v1_tag_length,
+	    calculate_size() - id3v1_tag_length);
+    if (!write_ptr) {
+	return -1;
+    }
     id3_tag_render(id3tag, write_ptr);
 
     return 0;
+}
+
+/*
+ * Get the actual number of bytes in the encoded file, i.e. without any
+ * padding.  Valid only after encode_finish() has been called.
+ */
+size_t Mp3Encoder::get_actual_size() const {
+    return actual_size;
 }
 
 /*
@@ -263,9 +285,17 @@ int Mp3Encoder::render_tag(Buffer& buffer) {
  * Cast to 64-bit int to avoid overflow.
  */
 size_t Mp3Encoder::calculate_size() const {
-    return id3size + 128
-    + (uint64_t)lame_get_totalframes(lame_encoder)*144*params.bitrate*10
-    / (lame_get_out_samplerate(lame_encoder)/100);
+    if (actual_size != 0) {
+	return actual_size;
+    } else if (params.vbr) {
+	return id3size + id3v1_tag_length + MAX_VBR_FRAME_SIZE
+	+ (uint64_t)lame_get_totalframes(lame_encoder)*144*params.bitrate*10
+	/ (lame_get_in_samplerate(lame_encoder)/100);
+    } else {
+	return id3size + id3v1_tag_length
+	+ (uint64_t)lame_get_totalframes(lame_encoder)*144*params.bitrate*10
+	/ (lame_get_out_samplerate(lame_encoder)/100);
+    }
 }
 
 /*
@@ -332,6 +362,23 @@ int Mp3Encoder::encode_finish(Buffer& buffer) {
     }
 
     buffer.increment_pos(len);
+    actual_size = buffer.tell() + id3v1_tag_length;
+
+    /*
+     * Write the VBR tag data at id3size bytes after the beginning.  lame
+     * already put dummy bytes here when lame_init_params() was called.
+     */
+    if (params.vbr) {
+        uint8_t* write_ptr = buffer.write_prepare(MAX_VBR_FRAME_SIZE, id3size);
+        if (!write_ptr) {
+	    return -1;
+        }
+        size_t vbr_tag_size = lame_get_lametag_frame(lame_encoder, write_ptr,
+		MAX_VBR_FRAME_SIZE);
+        if (vbr_tag_size > MAX_VBR_FRAME_SIZE) {
+	   return -1;
+        }
+    }
 
     return len;
 }

--- a/src/mp3_encoder.h
+++ b/src/mp3_encoder.h
@@ -30,7 +30,7 @@
 
 class Mp3Encoder : public Encoder {
 public:
-    Mp3Encoder();
+    Mp3Encoder(size_t actual_size);
     ~Mp3Encoder();
 
     int set_stream_params(uint64_t num_samples, int sample_rate,
@@ -41,12 +41,18 @@ public:
                          int data_length);
     void set_gain_db(const double dbgain);
     int render_tag(Buffer& buffer);
+    size_t get_actual_size() const;
     size_t calculate_size() const;
     int encode_pcm_data(const int32_t* const data[], int numsamples,
                         int sample_size, Buffer& buffer);
     int encode_finish(Buffer& buffer);
+
+public:
+    static const size_t id3v1_tag_length = 128;
+
 private:
     lame_t lame_encoder;
+    size_t actual_size;    // Use this as the size instead of computing it.
     struct id3_tag* id3tag;
     size_t id3size;
     typedef std::map<int,const char*> meta_map_t;

--- a/src/mp3_encoder.h
+++ b/src/mp3_encoder.h
@@ -30,6 +30,8 @@
 
 class Mp3Encoder : public Encoder {
 public:
+    static const size_t id3v1_tag_length = 128;
+
     Mp3Encoder(size_t actual_size);
     ~Mp3Encoder();
 
@@ -46,9 +48,6 @@ public:
     int encode_pcm_data(const int32_t* const data[], int numsamples,
                         int sample_size, Buffer& buffer);
     int encode_finish(Buffer& buffer);
-
-public:
-    static const size_t id3v1_tag_length = 128;
 
 private:
     lame_t lame_encoder;

--- a/src/mp3fs.c
+++ b/src/mp3fs.c
@@ -40,6 +40,8 @@ struct mp3fs_params params = {
     .basepath   = NULL,
     .bitrate    = 128,
     .quality    = 5,
+    .vbr        = 0,
+    .statcachesize = 0,
     .debug      = 0,
     .gainmode   = 1,
     .gainref    = 89.0,
@@ -63,6 +65,10 @@ static struct fuse_opt mp3fs_opts[] = {
     MP3FS_OPT("debug",            debug, 1),
     MP3FS_OPT("-b %u",            bitrate, 0),
     MP3FS_OPT("bitrate=%u",       bitrate, 0),
+    MP3FS_OPT("--vbr",            vbr, 1),
+    MP3FS_OPT("vbr",              vbr, 1),
+    MP3FS_OPT("--statcachesize=%u", statcachesize, 0),
+    MP3FS_OPT("statcachesize=%u", statcachesize, 1),
     MP3FS_OPT("--gainmode=%d",    gainmode, 0),
     MP3FS_OPT("gainmode=%d",      gainmode, 0),
     MP3FS_OPT("--gainref=%f",     gainref, 0),
@@ -92,6 +98,15 @@ Encoding options:\n\
                            encoding bitrate: Acceptable values for RATE\n\
                            include 96, 112, 128, 160, 192, 224, 256, and\n\
                            320; 128 is the default\n\
+    --vbr, -ovbr           Use variable bit rate encoding.  When set, the\n\
+                           bit rate set with '-b' sets the maximum bit rate.\n\
+                           Performance will be terrible unless the\n\
+			   statcachesize is enabled.\n\
+    --statcachesize=SIZE, -ostatcachesize=SIZE\n\
+			   Set the cache for file stats, where SIZE is in\n\
+			   kilobytes.  Necessary for decent performance when\n\
+			   VBR is enabled.  A megabytes holds stats for on\n\
+			   the order of 10,000 files.\n\
     --gainmode=<0,1,2>, -ogainmode=<0,1,2>\n\
                            what to do with ReplayGain tags:\n\
                            0 - ignore, 1 - prefer album gain (default),\n\
@@ -196,12 +211,15 @@ int main(int argc, char *argv[]) {
                 "basepath:  %s\n"
                 "bitrate:   %u\n"
                 "quality:   %u\n"
+                "vbr:       %u\n"
+                "statcachesize: %u\n"
                 "gainmode:  %d\n"
                 "gainref:   %f\n"
                 "desttype:  %s\n"
                 "\n",
-                params.basepath, params.bitrate, params.quality,
-                params.gainmode, params.gainref, params.desttype);
+                params.basepath, params.bitrate, params.quality, params.vbr,
+                params.statcachesize, params.gainmode, params.gainref,
+		params.desttype);
 
     // start FUSE
     ret = fuse_main(args.argc, args.argv, &mp3fs_ops, NULL);

--- a/src/mp3fs.c
+++ b/src/mp3fs.c
@@ -103,10 +103,9 @@ Encoding options:\n\
                            Performance will be terrible unless the\n\
                            statcachesize is enabled.\n\
     --statcachesize=SIZE, -ostatcachesize=SIZE\n\
-                           Set the cache for file stats, where SIZE is in\n\
-                           kilobytes.  Necessary for decent performance when\n\
-                           VBR is enabled.  A megabytes holds stats for on\n\
-                           the order of 10,000 files.\n\
+                           Set the number of entries for the file stats\n\
+                           cache.  Necessary for decent performance when\n\
+                           VBR is enabled.  Each entry takes 100-200 bytes.\n\
     --gainmode=<0,1,2>, -ogainmode=<0,1,2>\n\
                            what to do with ReplayGain tags:\n\
                            0 - ignore, 1 - prefer album gain (default),\n\

--- a/src/mp3fs.c
+++ b/src/mp3fs.c
@@ -37,14 +37,14 @@
 #endif
 
 struct mp3fs_params params = {
-    .basepath   = NULL,
-    .bitrate    = 128,
-    .quality    = 5,
-    .vbr        = 0,
-    .statcachesize = 0,
-    .debug      = 0,
-    .gainmode   = 1,
-    .gainref    = 89.0,
+    .basepath        = NULL,
+    .bitrate         = 128,
+    .quality         = 5,
+    .vbr             = 0,
+    .statcachesize   = 0,
+    .debug           = 0,
+    .gainmode        = 1,
+    .gainref         = 89.0,
 #ifdef HAVE_MP3
     .desttype  = "mp3",
 #endif
@@ -59,29 +59,29 @@ enum {
 #define MP3FS_OPT(t, p, v) { t, offsetof(struct mp3fs_params, p), v }
 
 static struct fuse_opt mp3fs_opts[] = {
-    MP3FS_OPT("--quality=%u",     quality, 0),
-    MP3FS_OPT("quality=%u",       quality, 0),
-    MP3FS_OPT("-d",               debug, 1),
-    MP3FS_OPT("debug",            debug, 1),
-    MP3FS_OPT("-b %u",            bitrate, 0),
-    MP3FS_OPT("bitrate=%u",       bitrate, 0),
-    MP3FS_OPT("--vbr",            vbr, 1),
-    MP3FS_OPT("vbr",              vbr, 1),
-    MP3FS_OPT("--statcachesize=%u", statcachesize, 0),
-    MP3FS_OPT("statcachesize=%u", statcachesize, 1),
-    MP3FS_OPT("--gainmode=%d",    gainmode, 0),
-    MP3FS_OPT("gainmode=%d",      gainmode, 0),
-    MP3FS_OPT("--gainref=%f",     gainref, 0),
-    MP3FS_OPT("gainref=%f",       gainref, 0),
-    MP3FS_OPT("--desttype=%s",    desttype, 0),
-    MP3FS_OPT("desttype=%s",      desttype, 0),
+    MP3FS_OPT("--quality=%u",         quality, 0),
+    MP3FS_OPT("quality=%u",           quality, 0),
+    MP3FS_OPT("-d",                   debug, 1),
+    MP3FS_OPT("debug",                debug, 1),
+    MP3FS_OPT("-b %u",                bitrate, 0),
+    MP3FS_OPT("bitrate=%u",           bitrate, 0),
+    MP3FS_OPT("--vbr",                vbr, 1),
+    MP3FS_OPT("vbr",                  vbr, 1),
+    MP3FS_OPT("--statcachesize=%u",   statcachesize, 0),
+    MP3FS_OPT("statcachesize=%u",     statcachesize, 1),
+    MP3FS_OPT("--gainmode=%d",        gainmode, 0),
+    MP3FS_OPT("gainmode=%d",          gainmode, 0),
+    MP3FS_OPT("--gainref=%f",         gainref, 0),
+    MP3FS_OPT("gainref=%f",           gainref, 0),
+    MP3FS_OPT("--desttype=%s",        desttype, 0),
+    MP3FS_OPT("desttype=%s",          desttype, 0),
 
-    FUSE_OPT_KEY("-h",            KEY_HELP),
-    FUSE_OPT_KEY("--help",        KEY_HELP),
-    FUSE_OPT_KEY("-V",            KEY_VERSION),
-    FUSE_OPT_KEY("--version",     KEY_VERSION),
-    FUSE_OPT_KEY("-d",            KEY_KEEP_OPT),
-    FUSE_OPT_KEY("debug",         KEY_KEEP_OPT),
+    FUSE_OPT_KEY("-h",                KEY_HELP),
+    FUSE_OPT_KEY("--help",            KEY_HELP),
+    FUSE_OPT_KEY("-V",                KEY_VERSION),
+    FUSE_OPT_KEY("--version",         KEY_VERSION),
+    FUSE_OPT_KEY("-d",                KEY_KEEP_OPT),
+    FUSE_OPT_KEY("debug",             KEY_KEEP_OPT),
     FUSE_OPT_END
 };
 
@@ -101,12 +101,12 @@ Encoding options:\n\
     --vbr, -ovbr           Use variable bit rate encoding.  When set, the\n\
                            bit rate set with '-b' sets the maximum bit rate.\n\
                            Performance will be terrible unless the\n\
-			   statcachesize is enabled.\n\
+                           statcachesize is enabled.\n\
     --statcachesize=SIZE, -ostatcachesize=SIZE\n\
-			   Set the cache for file stats, where SIZE is in\n\
-			   kilobytes.  Necessary for decent performance when\n\
-			   VBR is enabled.  A megabytes holds stats for on\n\
-			   the order of 10,000 files.\n\
+                           Set the cache for file stats, where SIZE is in\n\
+                           kilobytes.  Necessary for decent performance when\n\
+                           VBR is enabled.  A megabytes holds stats for on\n\
+                           the order of 10,000 files.\n\
     --gainmode=<0,1,2>, -ogainmode=<0,1,2>\n\
                            what to do with ReplayGain tags:\n\
                            0 - ignore, 1 - prefer album gain (default),\n\
@@ -208,18 +208,18 @@ int main(int argc, char *argv[]) {
     openlog("mp3fs", params.debug ? LOG_PERROR : 0, LOG_USER);
 
     mp3fs_debug("MP3FS options:\n"
-                "basepath:  %s\n"
-                "bitrate:   %u\n"
-                "quality:   %u\n"
-                "vbr:       %u\n"
-                "statcachesize: %u\n"
-                "gainmode:  %d\n"
-                "gainref:   %f\n"
-                "desttype:  %s\n"
+                "basepath:       %s\n"
+                "bitrate:        %u\n"
+                "quality:        %u\n"
+                "vbr:            %u\n"
+                "statcachesize:  %u\n"
+                "gainmode:       %d\n"
+                "gainref:        %f\n"
+                "desttype:       %s\n"
                 "\n",
                 params.basepath, params.bitrate, params.quality, params.vbr,
                 params.statcachesize, params.gainmode, params.gainref,
-		params.desttype);
+                params.desttype);
 
     // start FUSE
     ret = fuse_main(args.argc, args.argv, &mp3fs_ops, NULL);

--- a/src/stats_cache.cc
+++ b/src/stats_cache.cc
@@ -36,12 +36,14 @@ void FileStat::update_atime() {
 }
 
 namespace {
-    /* Compare two cache entries by the access time of the FileStat objects. */
 
-    bool cmp_by_atime(const StatsCache::cache_entry_t& a1,
-            const StatsCache::cache_entry_t& a2) {
-        return a1.second.get_atime() < a2.second.get_atime();
-    }
+/* Compare two cache entries by the access time of the FileStat objects. */
+
+bool cmp_by_atime(const StatsCache::cache_entry_t& a1,
+        const StatsCache::cache_entry_t& a2) {
+    return a1.second.get_atime() < a2.second.get_atime();
+}
+
 }
 
 /*

--- a/src/stats_cache.cc
+++ b/src/stats_cache.cc
@@ -1,0 +1,142 @@
+/*
+ * File stats cache source for mp3fs
+ *
+ * Copyright (C) 2008-2013 K. Henriksson
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include "stats_cache.h"
+#include "transcode.h"
+
+#include <algorithm>
+#include <cerrno>
+#include <vector>
+
+FileStat::FileStat(size_t _size, time_t _mtime) : size(_size), mtime(_mtime) {
+    update_atime();
+}
+
+void FileStat::update_atime() {
+    struct timeval tv;
+    gettimeofday(&tv, 0);
+    atime = tv.tv_sec;
+}
+
+namespace {
+    /* Compare two cache entries by the access time of the FileStat objects. */
+
+    bool cmp_by_atime(const StatsCache::cache_entry_t& a1,
+            const StatsCache::cache_entry_t& a2) {
+        return a1.second.get_atime() < a2.second.get_atime();
+    }
+}
+
+/*
+ * Get the file size from the cache for the given filename, if it exists.
+ * Use 'mtime' as the modified time of the file to check for an invalid cache
+ * entry. Return true if the file size was found.
+ */
+bool StatsCache::get_filesize(const std::string& filename, time_t mtime,
+        size_t& filesize) {
+    bool in_cache = false;
+    pthread_mutex_lock(&mutex);
+    cache_t::iterator p = cache.find(filename);
+    if (p != cache.end()) {
+        FileStat& file_stat = p->second;
+        if (mtime > file_stat.get_mtime()) {
+            // The decoded file has changed since this entry was created, so
+            // remove the invalid entry.
+            mp3fs_debug("Removed out of date file '%s' from stats cache",
+                    p->first.c_str());
+            cache.erase(p);
+        } else {
+            mp3fs_debug("Found file '%s' in stats cache with size %u",
+                    p->first.c_str(), file_stat.get_size());
+            in_cache = true;
+            filesize = file_stat.get_size();
+            file_stat.update_atime();
+        }
+    }
+    pthread_mutex_unlock(&mutex);
+    return in_cache;
+}
+
+/* Add or update an entry in the stats cache */
+
+void StatsCache::put_filesize(const std::string& filename, size_t filesize,
+        time_t mtime) {
+    FileStat file_stat(filesize, mtime);
+    pthread_mutex_lock(&mutex);
+    cache_t::iterator p = cache.find(filename);
+    if (p == cache.end()) {
+        mp3fs_debug("Added file '%s' to stats cache with size %u",
+                filename.c_str(), file_stat.get_size());
+        cache.insert(std::make_pair(filename, file_stat));
+    } else if (mtime >= p->second.get_mtime()) {
+        mp3fs_debug("Updated file '%s' in stats cache with size %u",
+                filename.c_str(), file_stat.get_size());
+        p->second = file_stat;
+    }
+    check_size();
+    pthread_mutex_unlock(&mutex);
+}
+
+/*
+ * If the cache has exceeded the allotted size, prune invalid and old cache
+ * entries until the cache is at 90% of capacity. Assumes the cache is locked.
+ */
+void StatsCache::check_size() {
+    if (cache.size() <= params.statcachesize) {
+        return;
+    }
+
+    mp3fs_debug("Pruning stats cache");
+    size_t target_size = 9 * params.statcachesize / 10; // 90%
+    std::vector<cache_entry_t> sorted_entries;
+
+    /* First remove all invalid cache entries. */
+    cache_t::iterator next_p;
+    for (cache_t::iterator p = cache.begin(); p != cache.end(); p = next_p) {
+        const std::string& decoded_file = p->first;
+        const FileStat& file_stat = p->second;
+        next_p = p;
+        ++next_p;
+
+        struct stat s;
+        if (stat(decoded_file.c_str(), &s) < 0 ||
+                s.st_mtime > file_stat.get_mtime()) {
+            mp3fs_debug("Removed out of date file '%s' from stats cache",
+                    p->first.c_str());
+            errno = 0;
+            cache.erase(p);
+        } else {
+            sorted_entries.push_back(*p);
+        }
+    }
+    if (cache.size() <= target_size) {
+        return;
+    }
+
+    // Sort all cache entries by the atime, and remove the oldest entries until
+    // the cache size meets the target.
+    sort(sorted_entries.begin(), sorted_entries.end(), cmp_by_atime);
+    for (std::vector<cache_entry_t>::iterator p = sorted_entries.begin();
+            p != sorted_entries.end() && cache.size() > target_size; ++p) {
+        mp3fs_debug("Pruned oldest file '%s' from stats cache",
+                p->first.c_str());
+        cache.erase(p->first);
+    }
+}

--- a/src/stats_cache.h
+++ b/src/stats_cache.h
@@ -38,6 +38,7 @@ public:
     size_t get_size() const  { return size; }
     time_t get_atime() const { return atime; }
     time_t get_mtime() const { return mtime; }
+    bool operator==(const FileStat& other) const;
 private:
     size_t size;
     // The last time this object was accessed. Used to implement the most
@@ -62,7 +63,8 @@ public:
     void put_filesize(const std::string& filename, size_t filesize,
             time_t mtime);
 private:
-    void check_size();
+    void prune();
+    void remove_entry(const std::string& file, const FileStat& file_stat);
     cache_t cache;
     pthread_mutex_t mutex;
 };

--- a/src/stats_cache.h
+++ b/src/stats_cache.h
@@ -1,0 +1,70 @@
+/*
+ * File stats cache interface for mp3fs
+ *
+ * Copyright (C) 2008-2013 K. Henriksson
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#ifndef STATS_CACHE_H
+#define STATS_CACHE_H
+
+#include <map>
+#include <pthread.h>
+#include <string>
+#include <sys/time.h>
+
+/*
+ * Holds the size and modified time for a file, and is used in the file stats
+ * cache.
+ */
+class FileStat {
+public:
+    FileStat(size_t _size, time_t _mtime);
+
+    void update_atime();
+    size_t get_size() const  { return size; }
+    time_t get_atime() const { return atime; }
+    time_t get_mtime() const { return mtime; }
+private:
+    size_t size;
+    // The last time this object was accessed. Used to implement the most
+    // recently used cache policy.
+    time_t atime;
+    // The modified time of the decoded file when the size was computed.
+    time_t mtime;
+};
+    
+class StatsCache {
+public:
+    typedef std::map<std::string, FileStat> cache_t;
+    typedef std::pair<std::string, FileStat> cache_entry_t;
+
+    StatsCache() : mutex(PTHREAD_MUTEX_INITIALIZER) {}
+    ~StatsCache()                            { pthread_mutex_destroy(&mutex); }
+    StatsCache(const StatsCache&)            = delete;
+    StatsCache& operator=(const StatsCache&) = delete;
+
+    bool get_filesize(const std::string& filename, time_t mtime,
+            size_t& filesize);
+    void put_filesize(const std::string& filename, size_t filesize,
+            time_t mtime);
+private:
+    void check_size();
+    cache_t cache;
+    pthread_mutex_t mutex;
+};
+
+#endif

--- a/src/transcode.cc
+++ b/src/transcode.cc
@@ -180,11 +180,13 @@ ssize_t transcoder_read(struct transcoder* trans, char* buff, off_t offset,
         return -1;
     }
 
-    // truncate if we didn't actually get len
-    if (trans->buffer.tell() < (size_t) offset) {
-        len = 0;
-    } else if (trans->buffer.tell() < offset + len) {
-        len = trans->buffer.tell() - offset;
+    // truncate if we didnt actually get len
+    if (trans->buffer.tell() < offset + len) {
+        if ((size_t)offset < trans->buffer.tell()) {
+            len = trans->buffer.tell() - offset;
+        } else {
+            len = 0;
+        }
     }
 
     trans->buffer.copy_into((uint8_t*)buff, offset, len);

--- a/src/transcode.cc
+++ b/src/transcode.cc
@@ -19,20 +19,212 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#include "mp3_encoder.h"
 #include "transcode.h"
 
+#include <algorithm>
 #include <cerrno>
 #include <cstring>
+#include <limits>
+#include <map>
+#include <pthread.h>
+#include <string>
+#include <sys/time.h>
+#include <vector>
 
 #include "coders.h"
 
+using std::make_pair;
+using std::map;
+using std::numeric_limits;
+using std::pair;
+using std::sort;
+using std::string;
+using std::vector;
+
+/*
+ * Holds the size and modified time for a file, and is used in the file stats
+ * cache.
+ */
+class FileStat {
+public:
+    FileStat(size_t _size, time_t mtime);
+
+    void update_atime();
+    size_t get_size() const  { return size; }
+    time_t get_atime() const { return atime; }
+    time_t get_mtime() const { return mtime; }
+private:
+    size_t size;
+    // The last time this object was accessed.  Used to implement the most
+    // recently used cache policy.
+    time_t atime;
+
+    // The modified time of the decoded file when the size was computed.
+    time_t mtime;
+
+private:
+    // Default copy constructor, assignment operator, and destructor OK.
+    FileStat();
+};
+    
 /* Transcoder parameters for open mp3 */
 struct transcoder {
     Buffer buffer;
+    string filename;
+    size_t encoded_filesize;
 
     Encoder* encoder;
     Decoder* decoder;
 };
+
+static map<string, FileStat> cached_stats;
+static size_t cached_stats_size = 0;
+static pthread_mutex_t cached_stats_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+FileStat::FileStat(size_t _size, time_t _mtime) : size(_size), mtime(_mtime) {
+    update_atime();
+}
+
+void FileStat::update_atime() {
+    struct timeval tv;
+    gettimeofday(&tv, 0);
+    atime = tv.tv_sec;
+}
+
+/*
+ * Transcode the buffer until the buffer has enough or until an error occurs.
+ * The buffer needs at least 'end' bytes before transcoding stops.  Returns
+ * true if no errors and false otherwise.
+ */
+static bool do_transcode(struct transcoder* trans, size_t end) {
+    while (trans->encoder && trans->buffer.tell() < end) {
+	int stat = trans->decoder->process_single_fr(trans->encoder,
+						     &trans->buffer);
+	if (stat == -1 || (stat == 1 && transcoder_finish(trans) == -1)) {
+	    errno = EIO;
+	    return false;
+	}
+    }
+    return true;
+}
+
+/* Compute the size of a cache entry */
+
+static size_t cached_entry_size(const pair<string, FileStat>& cache_entry) {
+    return sizeof(pair<string, FileStat>) + cache_entry.first.capacity() +
+	    (3 * sizeof(size_t)) + // For GNU C++ string extra parts
+	    (3 * sizeof(void*));   // For map entry
+}
+
+/* Compare two FileStat objects by their access time */
+
+bool cmp_by_atime(const pair<string, FileStat>& a1,
+	const pair<string, FileStat>& a2) {
+    return a1.second.get_atime() < a2.second.get_atime();
+}
+
+/*
+ * Prune invalid and old cache entries until the cache is at 90% of
+ * capacity.  Assumes the cache is locked.
+ */
+static void prune_cache() {
+    mp3fs_debug("Pruning stats cache");
+    size_t target_size = params.statcachesize * 921; // 90% of 1k
+    vector< pair<string, FileStat> > sorted_entries;
+
+    /* First remove all invalid cache entries. */
+    map<string, FileStat>::iterator next_p;
+    for (map<string, FileStat>::iterator p = cached_stats.begin();
+	    p != cached_stats.end(); p = next_p) {
+	const string& decoded_file = p->first;
+	const FileStat& file_stat = p->second;
+	next_p = p;
+	++next_p;
+
+	struct stat s;
+	if (stat(decoded_file.c_str(), &s) < 0 ||
+		s.st_mtime > file_stat.get_mtime()) {
+	    mp3fs_debug("Removed out of date file '%s' from stats cache",
+		    p->first.c_str());
+	    errno = 0;
+	    cached_stats_size -= cached_entry_size(*p);
+	    cached_stats.erase(p);
+	} else {
+	    sorted_entries.push_back(*p);
+	}
+    }
+    if (cached_stats_size <= target_size) {
+	return;
+    }
+
+    // Sort all cache entries by the atime, and remove the oldest entries until
+    // the cache size meets the target.
+    sort(sorted_entries.begin(), sorted_entries.end(), cmp_by_atime);
+    for (vector< pair<string, FileStat> >::iterator p = sorted_entries.begin();
+	    p != sorted_entries.end() && cached_stats_size > target_size;
+	    ++p) {
+	mp3fs_debug("Pruned oldest file '%s' from stats cache",
+		p->first.c_str());
+	cached_stats_size -= cached_entry_size(*p);
+	cached_stats.erase(p->first);
+    }
+}
+
+/*
+ * Get the file size from the cache for the given filename, if it exists.
+ * Use 'mtime' as the modified time of the file to check for an invalid cache
+ * entry.  Return true if the file size was found.
+ */
+static bool get_cached_filesize(const string& filename, time_t mtime,
+	size_t& filesize) {
+    bool in_cache = false;
+    pthread_mutex_lock(&cached_stats_mutex);
+    map<string, FileStat>::iterator p = cached_stats.find(filename);
+    if (p != cached_stats.end()) {
+	FileStat& file_stat = p->second;
+	if (mtime > file_stat.get_mtime()) {
+	    // The decoded file has changed since this entry was created, so
+	    // remove the invalid entry.
+	    mp3fs_debug("Removed out of date file '%s' from stats cache",
+		    p->first.c_str());
+	    cached_stats_size -= cached_entry_size(*p);
+	    cached_stats.erase(p);
+	} else {
+	    mp3fs_debug("Found file '%s' in stats cache with size %u",
+		    p->first.c_str(), file_stat.get_size());
+	    in_cache = true;
+	    filesize = file_stat.get_size();
+	    file_stat.update_atime();
+	}
+    }
+    pthread_mutex_unlock(&cached_stats_mutex);
+    return in_cache;
+}
+
+/* Add or update an entry in the stats cache */
+
+static void put_cached_filesize(const string& filename, size_t filesize,
+	time_t mtime) {
+    FileStat file_stat(filesize, mtime);
+    pthread_mutex_lock(&cached_stats_mutex);
+    map<string, FileStat>::iterator p = cached_stats.find(filename);
+    if (p == cached_stats.end()) {
+        mp3fs_debug("Added file '%s' to stats cache with size %u",
+		filename.c_str(), file_stat.get_size());
+	map<string, FileStat>::iterator inserted_p =
+		cached_stats.insert(make_pair(filename, file_stat)).first;
+	cached_stats_size += cached_entry_size(*inserted_p);
+    } else if (mtime >= p->second.get_mtime()) {
+        mp3fs_debug("Updated file '%s' in stats cache with size %u",
+		filename.c_str(), file_stat.get_size());
+	p->second = file_stat;
+    }
+    if (cached_stats_size > params.statcachesize * 1024) {
+	prune_cache();
+    }
+    pthread_mutex_unlock(&cached_stats_mutex);
+}
 
 /* Use "C" linkage to allow access from C code. */
 extern "C" {
@@ -49,10 +241,11 @@ struct transcoder* transcoder_new(char* filename) {
     }
 
     /* Create Encoder and Decoder objects. */
-    trans->encoder = Encoder::CreateEncoder(params.desttype);
+    trans->filename = string(filename);
+    trans->encoded_filesize = 0;
     trans->decoder = Decoder::CreateDecoder(strrchr(filename, '.') + 1);
-    if (!trans->encoder || !trans->decoder) {
-        goto endecoder_fail;
+    if (!trans->decoder) {
+        goto decoder_fail;
     }
 
     mp3fs_debug("Ready to initialize decoder.");
@@ -62,6 +255,14 @@ struct transcoder* transcoder_new(char* filename) {
     }
 
     mp3fs_debug("Decoder initialized successfully.");
+
+    get_cached_filesize(trans->filename, trans->decoder->mtime(),
+	    trans->encoded_filesize);
+    trans->encoder = Encoder::CreateEncoder(params.desttype,
+	    trans->encoded_filesize);
+    if (!trans->encoder) {
+        goto encoder_fail;
+    }
 
     /*
      * Process metadata. The Decoder will call the Encoder to set appropriate
@@ -84,9 +285,10 @@ struct transcoder* transcoder_new(char* filename) {
 
     return trans;
 
-init_fail:
-endecoder_fail:
+encoder_fail:
     delete trans->decoder;
+decoder_fail:
+init_fail:
     delete trans->encoder;
 
     delete trans;
@@ -101,7 +303,7 @@ ssize_t transcoder_read(struct transcoder* trans, char* buff, off_t offset,
                         size_t len) {
     mp3fs_debug("Reading %zu bytes from offset %jd.", len, (intmax_t)offset);
     if ((size_t)offset > transcoder_get_size(trans)) {
-        return 0;
+        return -1;
     }
     if (offset + len > transcoder_get_size(trans)) {
         len = transcoder_get_size(trans) - offset;
@@ -116,37 +318,35 @@ ssize_t transcoder_read(struct transcoder* trans, char* buff, off_t offset,
      */
     if (strcmp(params.desttype, "mp3") == 0 &&
         (size_t)offset > trans->buffer.tell()
-        && offset + len > (transcoder_get_size(trans) - 128)) {
+        && offset + len >
+	(transcoder_get_size(trans) - Mp3Encoder::id3v1_tag_length)) {
         trans->buffer.copy_into((uint8_t*)buff, offset, len);
 
         return len;
     }
 
+    bool success = true;
     if (trans->decoder && trans->encoder) {
-        /* Transcode up to what we need, unless we encounter an error. */
-        while (trans->buffer.tell() < offset + len) {
-            int stat = trans->decoder->process_single_fr(trans->encoder,
-                                                         &trans->buffer);
-            if (stat == -1) {
-                errno = EIO;
-                return 0;
-            } else if (stat == 1) {
-                if (transcoder_finish(trans) == -1) {
-                    errno = EIO;
-                    return 0;
-                }
-                break;
-            }
-        }
+	if (strcmp(params.desttype, "mp3") == 0 && params.vbr) {
+	    /*
+	     * The Xing data (which is pretty close to the beginning of the
+	     * file) cannot be determined until the entire file is encoded, so
+	     * transcode the entire file for any read.
+	     */
+	    success = do_transcode(trans, numeric_limits<size_t>::max());
+	} else {
+	    success = do_transcode(trans, offset + len);
+	}
+    }
+    if (!success) {
+        return -1;
     }
 
-    // truncate if we didnt actually get len
-    if (trans->buffer.tell() < offset + len) {
-        if ((size_t)offset < trans->buffer.tell()) {
-            len = trans->buffer.tell() - offset;
-        } else {
-            len = 0;
-        }
+    // truncate if we didn't actually get len
+    if (trans->buffer.tell() < (size_t) offset) {
+	len = 0;
+    } else if (trans->buffer.tell() < offset + len) {
+	len = trans->buffer.tell() - offset;
     }
 
     trans->buffer.copy_into((uint8_t*)buff, offset, len);
@@ -158,7 +358,9 @@ ssize_t transcoder_read(struct transcoder* trans, char* buff, off_t offset,
 
 int transcoder_finish(struct transcoder* trans) {
     // flac cleanup
+    time_t decoded_file_mtime = 0;
     if (trans->decoder) {
+	decoded_file_mtime = trans->decoder->mtime();
         delete trans->decoder;
         trans->decoder = NULL;
     }
@@ -171,12 +373,16 @@ int transcoder_finish(struct transcoder* trans) {
         }
 
         /* Check encoded buffer size. */
-        mp3fs_debug("Finishing file. Predicted size: %zu, final size: %jd",
-                    trans->encoder->calculate_size(),
-                    (intmax_t)(trans->buffer.tell() + 128));
-        trans->buffer.increment_pos(128);
+	trans->encoded_filesize = trans->encoder->get_actual_size();
+        mp3fs_debug("Finishing file. Predicted size: %zu, final size: %zu",
+                    trans->encoder->calculate_size(), trans->encoded_filesize);
         delete trans->encoder;
         trans->encoder = NULL;
+    }
+
+    if (params.statcachesize > 0 && trans->encoded_filesize != 0) {
+	put_cached_filesize(trans->filename, trans->encoded_filesize,
+		decoded_file_mtime);
     }
 
     return 0;
@@ -185,14 +391,21 @@ int transcoder_finish(struct transcoder* trans) {
 /* Free the transcoder structure. */
 
 void transcoder_delete(struct transcoder* trans) {
-    transcoder_finish(trans);
+    if (trans->decoder) {
+        delete trans->decoder;
+    }
+    if (trans->encoder) {
+        delete trans->encoder;
+    }
     delete trans;
 }
 
 /* Return size of output file, as computed by Encoder. */
 size_t transcoder_get_size(struct transcoder* trans) {
-    if (trans->encoder) {
-        return trans->encoder->calculate_size();
+    if (trans->encoded_filesize != 0) {
+	return trans->encoded_filesize;
+    } else if (trans->encoder) {
+	return trans->encoder->calculate_size();
     } else {
         return trans->buffer.tell();
     }

--- a/src/transcode.cc
+++ b/src/transcode.cc
@@ -41,15 +41,15 @@ struct transcoder {
 };
 
 namespace {
-    StatsCache stats_cache;
-}
+
+StatsCache stats_cache;
 
 /*
  * Transcode the buffer until the buffer has enough or until an error occurs.
  * The buffer needs at least 'end' bytes before transcoding stops. Returns true
  * if no errors and false otherwise.
  */
-static bool transcode_until(struct transcoder* trans, size_t end) {
+bool transcode_until(struct transcoder* trans, size_t end) {
     while (trans->encoder && trans->buffer.tell() < end) {
         int stat = trans->decoder->process_single_fr(trans->encoder,
                                                      &trans->buffer);
@@ -59,6 +59,8 @@ static bool transcode_until(struct transcoder* trans, size_t end) {
         }
     }
     return true;
+}
+
 }
 
 /* Use "C" linkage to allow access from C code. */

--- a/src/transcode.h
+++ b/src/transcode.h
@@ -29,6 +29,8 @@ extern struct mp3fs_params {
     const char *basepath;
     unsigned int bitrate;
     unsigned int quality;
+    int vbr;
+    unsigned int statcachesize;
     int debug;
     int gainmode;
     float gainref;


### PR DESCRIPTION
This is my proposal for adding VBR encoding.  It takes khenriks' suggestion of using a pessimistic size for the file size a step further: it uses the pessimistic size (the size as if constant bit rate encoding was used) until the real file size is computed, and then caches this real file size and uses that size onwards.  Always using a pessimistic size is no better than just using CBR, so is pretty useless for VBR.

With the pessimistic size, the ID3v1 tag is still at the end of the file, but with empty space between the end of the encoded data and the tag.  This is necessary because MP3 readers always get the ID3v1 tag from the last 128 bytes of the file, regardless of what else is in the file.

The stat cache caches the file size, the modified time of the FLAC file, and the last time the cache entry was accessed.  The modified time is used to detect when the FLAC file has changed (thus invalidating the cache entry).  The access time is used to implement a least recently used cache policy, where the least recently used entries are removed when the cache gets above a threshold specified on the command line (--statcachesize).  When the cache reaches the threshold, 10% of the entries are removed (instead of just one entry) because the cost of purging can be a little expensive.

One tricky thing about VBR encoding the the Xing section.  This section has (among other things) the average encoding bitrate, which is used by most programs to compute the play time of the MP3.  This section is part of the first frame, so it is basically at the beginning of the file.  However, one doesn't know the average encoding bitrate until the entire file has been encoded.  So, lame writes dummy values in this section when it is first written, and then a call is made to rewrite this section once the encoding is done.  The implication of all this is that this implementation will encode the entire file for *any* read.

Because any read triggers an encoding of the entire file, performance is not that great in many real scenarios.  There really needs to be a file cache (in parallel with the stats cache) to cache a small number of files (really, a cache with just one entry would solve most of the problems).  But, this change was already big enough; the file cache can come later.