### PR TITLE
Replace 128 with a named constant

### DIFF
--- a/src/mp3_encoder.cc
+++ b/src/mp3_encoder.cc
@@ -250,7 +250,8 @@ int Mp3Encoder::render_tag(Buffer& buffer) {
 
     /* Write v1 tag at end of buffer. */
     id3_tag_options(id3tag, ID3_TAG_OPTION_ID3V1, ~0);
-    write_ptr = buffer.write_prepare(128, calculate_size() - 128);
+    write_ptr = buffer.write_prepare(id3v1_tag_length,
+            calculate_size() - id3v1_tag_length);
     id3_tag_render(id3tag, write_ptr);
 
     return 0;
@@ -263,7 +264,7 @@ int Mp3Encoder::render_tag(Buffer& buffer) {
  * Cast to 64-bit int to avoid overflow.
  */
 size_t Mp3Encoder::calculate_size() const {
-    return id3size + 128
+    return id3size + id3v1_tag_length
     + (uint64_t)lame_get_totalframes(lame_encoder)*144*params.bitrate*10
     / (lame_get_out_samplerate(lame_encoder)/100);
 }

--- a/src/mp3_encoder.h
+++ b/src/mp3_encoder.h
@@ -30,6 +30,8 @@
 
 class Mp3Encoder : public Encoder {
 public:
+    static const size_t id3v1_tag_length = 128;
+
     Mp3Encoder();
     ~Mp3Encoder();
 

--- a/src/transcode.cc
+++ b/src/transcode.cc
@@ -19,6 +19,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#include "mp3_encoder.h"
 #include "transcode.h"
 
 #include <cerrno>
@@ -116,7 +117,8 @@ ssize_t transcoder_read(struct transcoder* trans, char* buff, off_t offset,
      */
     if (strcmp(params.desttype, "mp3") == 0 &&
         (size_t)offset > trans->buffer.tell()
-        && offset + len > (transcoder_get_size(trans) - 128)) {
+        && offset + len >
+        (transcoder_get_size(trans) - Mp3Encoder::id3v1_tag_length)) {
         trans->buffer.copy_into((uint8_t*)buff, offset, len);
 
         return len;


### PR DESCRIPTION
Replace 128 (the ID3v1 tag length) with a named constant for clarity.
