### PR TITLE
Make the manpage generation reproducible.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,9 +11,13 @@ MAINTAINERCLEANFILES = mp3fs.1
 
 EXTRA_DIST = INSTALL.md README.md mp3fs.1.txt
 
+DATE_FMT = %B %Y
+SOURCE_DATE_EPOCH ?= $(shell date +%s)
+REVDATE = $(shell date -u -d "@(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null || date -u "+$(DATE_FMT)")
+
 mp3fs.1: mp3fs.1.txt
 	$(AM_V_GEN)a2x -a revnumber="$(VERSION)" \
-		-a revdate="$(shell date +'%B %Y')" -f manpage $<
+		-a revdate="$(REVDATE)" -f manpage $<
 
 # Remove absolutely every generated file
 .PHONY: squeaky-clean


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort, we noticed that mp3fs could not be built reproducibly as it uses a locale, timezone and current-time-of-date header in the generated manpage.

This patch ensures that the output is consistent regardless of the build user's location, or by the current time by utilising the [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/specs/source-date-epoch/) environment variable.