### PR TITLE
Added auto_cache flag to example, due to much better performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ Mount your filesystem like this:
 
 For example,
 
-    mp3fs -b 128 /mnt/music /mnt/mp3 -o allow_other,ro
+    mp3fs -b 128 /mnt/music /mnt/mp3 -o allow_other,ro,auto_cache
 
 In recent versions of FUSE and mp3fs, the same can be achieved with the
 following entry in `/etc/fstab`:
 
-    mp3fs#/mnt/music /mnt/mp3 fuse allow_other,ro,bitrate=128 0 0
+    mp3fs#/mnt/music /mnt/mp3 fuse allow_other,ro,auto_cache,bitrate=128 0 0
 
 At this point the files `/mnt/music/**.flac` and `/mnt/music/**.ogg` will
 show up as `/mnt/mp3/**.mp3`.


### PR DESCRIPTION
The **auto_cache** flag is improving performance a lot, because it will keep already encoded files within the cache for a while.
When using mp3fs as backend for a web media server it will speed up seeking an re-playing last played songs. Also via Samba I noticed some improvements.
I think it is worth adding it!

> auto_cache
              This option is an alternative to kernel_cache. Instead of
              unconditionally keeping cached data, the cached data is
              invalidated on open(2) if the modification time or the size of
              the file has changed since it was last opened.

More information:
http://man7.org/linux/man-pages/man8/mount.fuse.8.html
