### PR TITLE
Add description for mount option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ up as `/mnt/mp3/**.mp3`.
 **Tip:** If your mp3fs mount fails because the underlying filesystem hasn't
 been mounted yet, try adding the `x-systemd.requires-mounts-for=/mnt/music`
 mount option, where `/mnt/music` would be the location of the underlying mount.
+This will wait for the filesystem to be mounted. You might also have to add 
+`nofail` to prevent a missing mount from stopping the boot process.
 
 ## How it Works
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ up as `/mnt/mp3/**.mp3`.
 been mounted yet, try adding the `x-systemd.requires-mounts-for=/mnt/music`
 mount option, where `/mnt/music` would be the location of the underlying mount.
 This will wait for the filesystem to be mounted. You might also have to add 
-`nofail` to prevent a missing mount from stopping the boot process.
+`nofail` to prevent a missing mount from stopping the boot process. To be able
+to use this option you might need to install `fuse3`.
 
 ## How it Works
 


### PR DESCRIPTION
If underlying mount is required a missing mount might result in the boot process to hang. Add `nofail` option to prevent this. 