### PR TITLE
Add m3u, m3u8 and pls playlist support

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,7 @@
 INCLUDES = $(fuse_CFLAGS)
 
 bin_PROGRAMS = mp3fs
-mp3fs_SOURCES = mp3fs.cc mp3fs.h fuseops.cc transcode.cc transcode.h buffer.cc buffer.h stats_cache.cc stats_cache.h logging.cc logging.h reader.h path.cc path.h
+mp3fs_SOURCES = mp3fs.cc mp3fs.h fuseops.cc transcode.cc transcode.h buffer.cc buffer.h stats_cache.cc stats_cache.h logging.cc logging.h reader.h path.cc path.h playlist.cc playlist.h
 mp3fs_LDADD	= $(fuse_LIBS)
 
 SUBDIRS = codecs lib

--- a/src/fuseops.cc
+++ b/src/fuseops.cc
@@ -41,6 +41,7 @@
 #include "logging.h"
 #include "mp3fs.h"
 #include "path.h"
+#include "playlist.h"
 #include "reader.h"
 #include "transcode.h"
 
@@ -124,6 +125,12 @@ int mp3fs_getattr(const char* p, struct stat* stbuf) {
 
     /* pass-through for regular files */
     if (lstat(path.normal_source().c_str(), stbuf) == 0) {
+        if (S_ISREG(stbuf->st_mode) && is_playlist(path.normal_source())) {
+            const PlaylistReader reader(path.normal_source());
+            stbuf->st_size = static_cast<off_t>(reader.size());
+            stbuf->st_blocks =
+                (stbuf->st_size + kBytesPerBlock - 1) / kBytesPerBlock;
+        }
         return 0;
     }
 
@@ -155,7 +162,13 @@ int mp3fs_open(const char* p, struct fuse_file_info* fi) {
     const int fd = open(path.normal_source().c_str(), fi->flags);
 
     if (fd != -1) {  // File exists and was successfully opened.
-        fi->fh = reinterpret_cast<uint64_t>(new FileReader(fd));
+        if (is_playlist(path.normal_source())) {
+            close(fd);
+            fi->fh = reinterpret_cast<uint64_t>(
+                new PlaylistReader(path.normal_source()));
+        } else {
+            fi->fh = reinterpret_cast<uint64_t>(new FileReader(fd));
+        }
         return 0;
     }
     if (errno != ENOENT) {  // File exists but can't be opened.

--- a/src/playlist.cc
+++ b/src/playlist.cc
@@ -1,0 +1,141 @@
+/*
+ * Playlist file reader for MP3FS
+ *
+ * Copyright (C) 2026 Isaac Morales
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include "playlist.h"
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "codecs/coders.h"
+#include "mp3fs.h"
+
+namespace {
+
+std::string file_extension(const std::string& path) {
+    const size_t dot = path.rfind('.');
+    if (dot == std::string::npos) return {};
+    return path.substr(dot + 1);
+}
+
+/* Translate a single path token: replace a decodable extension with desttype. */
+std::string convert_extension(const std::string& path) {
+    const size_t ext_pos = path.rfind('.');
+    if (ext_pos != std::string::npos &&
+        Decoder::CreateDecoder(path.substr(ext_pos + 1)) != nullptr) {
+        return path.substr(0, ext_pos + 1) + params.desttype;
+    }
+    return path;
+}
+
+/*
+ * Translate an M3U / M3U8 stream.
+ * Lines beginning with '#' are directives and are passed through unchanged.
+ * All other non-empty lines are treated as file paths.
+ */
+std::string translate_m3u(std::istream& in) {
+    std::ostringstream out;
+    std::string line;
+    while (std::getline(in, line)) {
+        /* Strip Windows-style carriage return. */
+        if (!line.empty() && line.back() == '\r') {
+            line.pop_back();
+        }
+        if (!line.empty() && line[0] != '#') {
+            line = convert_extension(line);
+        }
+        out << line << '\n';
+    }
+    return out.str();
+}
+
+/*
+ * Translate a PLS stream.
+ * Only "File<N>=<path>" entries reference audio files; everything else
+ * (Title, Length, NumberOfEntries, Version, section headers) is passed
+ * through unchanged.
+ */
+std::string translate_pls(std::istream& in) {
+    std::ostringstream out;
+    std::string line;
+    while (std::getline(in, line)) {
+        if (!line.empty() && line.back() == '\r') {
+            line.pop_back();
+        }
+        /* Case-insensitive check for "File" prefix followed by digits and '='. */
+        if (line.size() >= 6) {
+            std::string lower = line.substr(0, 4);
+            std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+            if (lower == "file") {
+                const size_t eq = line.find('=');
+                if (eq != std::string::npos) {
+                    /* Verify the characters between "File" and '=' are digits. */
+                    bool all_digits = true;
+                    for (size_t i = 4; i < eq; ++i) {
+                        if (!std::isdigit(static_cast<unsigned char>(line[i]))) {
+                            all_digits = false;
+                            break;
+                        }
+                    }
+                    if (all_digits && eq > 4) {
+                        const std::string value = line.substr(eq + 1);
+                        out << line.substr(0, eq + 1) << convert_extension(value)
+                            << '\n';
+                        continue;
+                    }
+                }
+            }
+        }
+        out << line << '\n';
+    }
+    return out.str();
+}
+
+std::string translate_playlist(const std::string& source_path) {
+    std::ifstream f(source_path);
+    if (!f) return {};
+    const std::string ext = file_extension(source_path);
+    if (ext == "pls") {
+        return translate_pls(f);
+    }
+    return translate_m3u(f);
+}
+
+}  // namespace
+
+bool is_playlist(const std::string& path) {
+    const std::string ext = file_extension(path);
+    return ext == "m3u" || ext == "m3u8" || ext == "pls";
+}
+
+PlaylistReader::PlaylistReader(const std::string& source_path)
+    : content_(translate_playlist(source_path)) {}
+
+ssize_t PlaylistReader::read(char* buff, off_t offset, size_t len) {
+    if (offset < 0 || static_cast<size_t>(offset) >= content_.size()) {
+        return 0;
+    }
+    const size_t available = content_.size() - static_cast<size_t>(offset);
+    const size_t to_copy = std::min(len, available);
+    content_.copy(buff, to_copy, static_cast<size_t>(offset));
+    return static_cast<ssize_t>(to_copy);
+}

--- a/src/playlist.h
+++ b/src/playlist.h
@@ -1,0 +1,51 @@
+/*
+ * Playlist file reader for MP3FS
+ *
+ * Copyright (C) 2026 Isaac Morales
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#ifndef MP3FS_PLAYLIST_H_
+#define MP3FS_PLAYLIST_H_
+
+#include <string>
+
+#include "reader.h"
+
+/** Return true if path refers to a supported playlist format. */
+bool is_playlist(const std::string& path);
+
+/**
+ * Reader that serves a playlist file with source audio extensions translated
+ * to the transcoded destination extension.
+ *
+ * The entire translated content is materialised in memory on construction
+ * (playlist files are small) so that size reporting and random access both
+ * work without re-reading the source file.
+ */
+class PlaylistReader : public Reader {
+ public:
+    explicit PlaylistReader(const std::string& source_path);
+
+    ssize_t read(char* buff, off_t offset, size_t len) override;
+
+    size_t size() const { return content_.size(); }
+
+ private:
+    std::string content_;
+};
+
+#endif  // MP3FS_PLAYLIST_H_

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -4,6 +4,7 @@ TESTS = test_audio \
 	test_filenames \
 	test_filesize \
 	test_passthrough \
+	test_playlist \
 	test_picture \
 	test_readlink \
 	test_tags

--- a/test/srcdir/playlist.m3u
+++ b/test/srcdir/playlist.m3u
@@ -1,0 +1,6 @@
+#EXTM3U
+#EXTINF:6,Barack Obama - The Internet [excerpt]
+obama.fLaC
+ra[ven].ogg
+/music/random.flac
+some.txt

--- a/test/test_filenames
+++ b/test/test_filenames
@@ -2,5 +2,7 @@
 
 . "${BASH_SOURCE%/*}/funcs.sh"
 
+# TODO: ls -m is width sensitive. We should probably use ls -1 and compare without commas.
 check_equal "$(ls -m "$DIRNAME")" \
-    "dir.flac, obama.mp3, obama2.mp3, ra[ven].mp3, random.mp3, some.txt"
+    "dir.flac, obama.mp3, obama2.mp3, playlist.m3u, ra[ven].mp3, random.mp3,
+some.txt"

--- a/test/test_playlist
+++ b/test/test_playlist
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. "${BASH_SOURCE%/*}/funcs.sh"
+
+check_equal "$(cat "$DIRNAME/playlist.m3u")" \
+"#EXTM3U
+#EXTINF:6,Barack Obama - The Internet [excerpt]
+obama.mp3
+ra[ven].mp3
+/music/random.mp3
+some.txt"


### PR DESCRIPTION
When FLAC files are ripped and the ripper generates a .m3u playlist alongside them, mounting via mp3fs leaves the playlist referencing the original .flac (or .ogg) paths. Media players then can't find the files because the filesystem exposes them as .mp3.

This PR makes mp3fs  rewrite playlist content on the fly, the same way it renames audio files in directory listings.

This implements #38 after 12 years

P.D.: Is a vibe coded PR